### PR TITLE
Add : Extension description through GET method, for BlueOS extensions use.

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -21,6 +21,7 @@ pub async fn run() -> std::io::Result<()> {
             .service(protocols::v1::rest::post_neopixel)
             .service(protocols::v1::rest::get_led)
             .service(protocols::v1::rest::post_led)
+            .service(protocols::v1::rest::get_server_metadata)
     });
 
     server.bind(("0.0.0.0", 8080))?.run().await

--- a/src/server/protocols/v1/frontend/index.html
+++ b/src/server/protocols/v1/frontend/index.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-    <title>PWM Control</title>
+    <title>Navigator Assistant</title>
     <style>
         body {
             margin: 0;

--- a/src/server/protocols/v1/rest.rs
+++ b/src/server/protocols/v1/rest.rs
@@ -1,4 +1,7 @@
-use crate::{hardware_manager, server::protocols::v1::packages};
+use crate::{
+    hardware_manager,
+    server::protocols::v1::{packages, structures::ServerMetadata},
+};
 use actix_web::{get, post, web, HttpResponse, Responder};
 use mime_guess::from_path;
 use std::{str::FromStr, vec};
@@ -89,5 +92,12 @@ async fn post_pwm_frequency(path: web::Path<f32>) -> impl Responder {
     let frequency = path.into_inner();
     let package = packages::set_pwm_freq_hz(frequency);
     hardware_manager::pwm_enable(true);
+    HttpResponse::Ok().json(package)
+}
+
+/// The "register_service" route is used by BlueOS extensions manager
+#[get("register_service")]
+async fn get_server_metadata() -> impl Responder {
+    let package = ServerMetadata::default();
     HttpResponse::Ok().json(package)
 }

--- a/src/server/protocols/v1/structures.rs
+++ b/src/server/protocols/v1/structures.rs
@@ -126,3 +126,30 @@ impl Default for InputRequest {
         }
     }
 }
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ServerMetadata {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub icon: &'static str,
+    pub company: &'static str,
+    pub version: &'static str,
+    pub new_page: bool,
+    pub webpage: &'static str,
+    pub api: &'static str,
+}
+
+impl Default for ServerMetadata {
+    fn default() -> Self {
+        Self {
+            name: "Navigator Assistant",
+            description: "A navigator extension to expose navigator to web.",
+            icon: "mdi-compass-outline",
+            company: "BlueRobotics",
+            version: "0.0.1",
+            new_page: false,
+            webpage: "https://github.com/RaulTrombin/navigator-assistant",
+            api: "https://raultrombin.github.io/navigator-assistant/api",
+        }
+    }
+}


### PR DESCRIPTION
This PR provides the required json data for Navigator Assistant extension.

[BlueOS Extensions API services](
https://github.com/bluerobotics/BlueOS/wiki/Service-system-and-webapp#rest-api-method)