### PR TITLE
Add: Websocket service

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,15 +4,20 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+actix = "0.13.1"
 actix-web = "4.4.0"
+actix-web-actors = "4.2.0"
+actix-ws = "0.2.5"
 chrono = { version = "0.4.28", features = ["serde"] }
 derive-new = "0.5.9"
 env_logger = "0.10.0"
 futures = "0.3.28"
+futures-util = "0.3.28"
 lazy_static = "1.4.0"
 log = "0.4.20"
 mime_guess = "2.0.4"
 navigator-rs = "0.2.1"
+regex = "1.9.5"
 rust-embed = "8.0.0"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.105"

--- a/src/hardware_manager.rs
+++ b/src/hardware_manager.rs
@@ -7,7 +7,7 @@ use std::thread;
 #[derive(Default)]
 struct NavigationManager {
     navigator: navigator_rs::Navigator,
-    sentinel: Option<std::thread::JoinHandle<()>>,
+    monitor: Option<std::thread::JoinHandle<()>>,
 }
 #[derive(Debug, Clone, Default, Copy)]
 struct Data {
@@ -47,12 +47,12 @@ impl NavigationManager {
         &NAVIGATOR
     }
 
-    pub fn init_sensor_reading() {
-        NavigationManager::get_instance().lock().unwrap().sentinel =
-            Some(thread::spawn(|| NavigationManager::sensor_reading(500)))
+    pub fn init_monitor() {
+        NavigationManager::get_instance().lock().unwrap().monitor =
+            Some(thread::spawn(|| NavigationManager::monitor(500)))
     }
 
-    fn sensor_reading(refresh_interval: u64) {
+    fn monitor(refresh_interval: u64) {
         loop {
             let reading = with_navigator!().read_all();
             *DATA.write().unwrap() = Data { state: reading };
@@ -151,7 +151,7 @@ pub fn init() {
 }
 
 pub fn init_auto_reading() {
-    NavigationManager::init_sensor_reading();
+    NavigationManager::init_monitor();
 }
 
 pub fn set_led(select: UserLed, state: bool) {

--- a/src/hardware_manager.rs
+++ b/src/hardware_manager.rs
@@ -1,5 +1,7 @@
+use crate::server::protocols::v1::{packages, websocket};
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use std::convert::From;
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
@@ -56,8 +58,18 @@ impl NavigationManager {
         loop {
             let reading = with_navigator!().read_all();
             *DATA.write().unwrap() = Data { state: reading };
+
+            // Todo, websockeat inputs broadcast enable, and if sync/not(different interval)
+            NavigationManager::websocket_broadcast();
+
             thread::sleep(std::time::Duration::from_millis(refresh_interval));
         }
+    }
+
+    fn websocket_broadcast() {
+        let package: crate::server::protocols::v1::structures::AnsPackage =
+            packages::reading(packages::Sensors::All);
+        websocket::send_to_websockets(json!(package));
     }
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,4 +1,4 @@
-use actix_web::{middleware, App, HttpServer};
+use actix_web::{middleware, web, App, HttpServer};
 pub mod protocols;
 
 #[derive(rust_embed::RustEmbed)]
@@ -22,6 +22,7 @@ pub async fn run() -> std::io::Result<()> {
             .service(protocols::v1::rest::get_led)
             .service(protocols::v1::rest::post_led)
             .service(protocols::v1::rest::get_server_metadata)
+            .service(web::resource("/ws").route(web::get().to(protocols::v1::websocket::websocket)))
     });
 
     server.bind(("0.0.0.0", 8080))?.run().await

--- a/src/server/protocols/v1/mod.rs
+++ b/src/server/protocols/v1/mod.rs
@@ -1,3 +1,4 @@
 pub mod packages;
 pub mod rest;
 pub mod structures;
+pub mod websocket;

--- a/src/server/protocols/v1/websocket.rs
+++ b/src/server/protocols/v1/websocket.rs
@@ -1,0 +1,163 @@
+use actix::{Actor, Addr, AsyncContext, Handler, Message, StreamHandler};
+use actix_web::{web, HttpRequest, HttpResponse};
+use actix_web_actors::ws;
+use lazy_static::lazy_static;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::{
+    str::FromStr,
+    sync::{Arc, Mutex},
+};
+
+use crate::server::protocols::v1::packages;
+
+pub struct StringMessage(String);
+
+impl Message for StringMessage {
+    type Result = ();
+}
+
+#[derive(Serialize, Debug)]
+pub struct WebsocketError {
+    pub error: String,
+}
+
+#[derive(Debug)]
+pub struct WebsocketActorContent {
+    pub actor: Addr<WebsocketActor>,
+    pub re: Option<Regex>,
+}
+
+#[derive(Debug, Default)]
+pub struct WebsocketManager {
+    pub clients: Vec<WebsocketActorContent>,
+}
+
+impl WebsocketManager {
+    pub fn send(&self, value: &serde_json::Value, name: &str) {
+        if self.clients.is_empty() {
+            return;
+        }
+
+        let string = serde_json::to_string_pretty(value).unwrap();
+        for client in &self.clients {
+            let is_match = client.re.as_ref().map_or(false, |regx| regx.is_match(name));
+            if is_match {
+                client.actor.do_send(StringMessage(string.clone()));
+            }
+        }
+    }
+    pub fn get_client_count(&self) -> usize {
+        self.clients.len()
+    }
+}
+
+lazy_static! {
+    static ref MANAGER: Arc<Mutex<WebsocketManager>> =
+        Arc::new(Mutex::new(WebsocketManager::default()));
+}
+
+pub fn send_to_websockets(message: Value) {
+    MANAGER.lock().unwrap().send(&message, &message.to_string());
+}
+
+#[derive(Debug)]
+pub struct WebsocketActor {
+    server: Arc<Mutex<WebsocketManager>>,
+    pub filter: String,
+}
+
+impl WebsocketActor {
+    pub fn new(message_filter: String) -> Self {
+        Self {
+            server: MANAGER.clone(),
+            filter: message_filter,
+        }
+    }
+}
+
+impl Handler<StringMessage> for WebsocketActor {
+    type Result = ();
+
+    fn handle(&mut self, message: StringMessage, context: &mut Self::Context) {
+        context.text(message.0);
+    }
+}
+
+impl Actor for WebsocketActor {
+    type Context = ws::WebsocketContext<Self>;
+}
+
+impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WebsocketActor {
+    fn started(&mut self, ctx: &mut Self::Context) {
+        println!("Starting websocket, add itself in manager.");
+        self.server
+            .lock()
+            .unwrap()
+            .clients
+            .push(WebsocketActorContent {
+                actor: ctx.address(),
+                re: Regex::new(&self.filter).ok(),
+            });
+    }
+
+    fn finished(&mut self, ctx: &mut Self::Context) {
+        println!("Finishing websocket, remove itself from manager.");
+        self.server
+            .lock()
+            .unwrap()
+            .clients
+            .retain(|x| x.actor != ctx.address());
+    }
+
+    fn handle(&mut self, msg: Result<ws::Message, ws::ProtocolError>, ctx: &mut Self::Context) {
+        match msg {
+            Ok(ws::Message::Ping(msg)) => ctx.pong(&msg),
+            Ok(ws::Message::Text(text)) => {
+                let text = text.trim();
+                if text.starts_with('/') {
+                    let v: Vec<&str> = text.splitn(5, '/').collect();
+                    match v[1] {
+                        "input" => {
+                            let package =
+                                packages::reading(packages::Sensors::from_str(v[2]).unwrap());
+                            ctx.text(json!(package).to_string());
+                        }
+                        "get_connected" => {
+                            ctx.text(
+                                json!(self.server.lock().unwrap().get_client_count()).to_string(),
+                            );
+                        }
+                        _ => ctx.text(json!("Error: Invalid command selected").to_string()),
+                    }
+                } else {
+                    ctx.text(json!("Error: Invalid command").to_string())
+                }
+            }
+            Ok(ws::Message::Binary(bin)) => ctx.binary(bin),
+            _ => (),
+        }
+    }
+}
+
+pub async fn websocket(
+    req: HttpRequest,
+    query: web::Query<WebsocketQuery>,
+    stream: web::Payload,
+) -> Result<HttpResponse, actix_web::Error> {
+    let filter = match query.into_inner().filter {
+        Some(filter) => filter,
+        _ => ".*".to_owned(),
+    };
+
+    log::debug!("New websocket with filter {:#?}", &filter);
+
+    ws::start(WebsocketActor::new(filter), &req, stream)
+}
+
+#[derive(Deserialize)]
+pub struct WebsocketQuery {
+    /// Regex filter to select the desired incoming messages
+    filter: Option<String>,
+}


### PR DESCRIPTION
This PR adds the websocket service,
It used the mavlink2rest as base, a simplified version of the handlers and structures.

User is abble to:
1 - connect to websocket service with regex filter
    & receive inputs monitor broadcasting like GET method

2 - send commands using /, rest like commands for /input/ route, like rest service (all/magnetometer.../adc)

3 - send  /get_connected to know connected users on websocket.

![image](https://github.com/RaulTrombin/navigator-assistant/assets/80598030/7609a5dd-cf08-4f74-b05c-7e731e00e364)
![image](https://github.com/RaulTrombin/navigator-assistant/assets/80598030/e4c2ac01-d7b0-4e23-9217-e12f9fd97825)
