### PR TITLE
[Add] Route to outputs on websocket, and multiple requests

### DIFF
--- a/src/server/protocols/v1/websocket.rs
+++ b/src/server/protocols/v1/websocket.rs
@@ -118,113 +118,20 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WebsocketActor {
         match msg {
             Ok(ws::Message::Ping(msg)) => ctx.pong(&msg),
             Ok(ws::Message::Text(text)) => {
-                let text = text.trim();
-                if text.starts_with('/') {
-                    let v: Vec<&str> = text.splitn(5, '/').collect();
-                    match v[1] {
-                        "input" => {
-                            let package =
-                                packages::reading(packages::Sensors::from_str(v[2]).unwrap());
-                            ctx.text(json!(package).to_string());
-                        }
-                        "output" => match v[2] {
-                            "userled" => {
-                                let package;
-                                if v.len() == 4 {
-                                    package = packages::get_led(
-                                        hardware_manager::UserLed::from_str(v[3]).unwrap(),
-                                    );
-                                    ctx.text(json!(package).to_string())
-                                } else if v.len() == 5 {
-                                    let state: bool = v[4].parse::<bool>().unwrap();
-                                    package = packages::set_led(
-                                        hardware_manager::UserLed::from_str(v[3]).unwrap(),
-                                        state,
-                                    );
-                                    ctx.text(json!(package).to_string())
-                                } else {
-                                    ctx.text(json!("Error: Invalid command selected").to_string())
-                                }
-                            }
-                            "nepixel" => {
-                                if v.len() == 6 {
-                                    let (red, green, blue) = (
-                                        v[3].parse::<u8>().unwrap(),
-                                        v[4].parse::<u8>().unwrap(),
-                                        v[5].parse::<u8>().unwrap(),
-                                    );
-                                    let package = packages::set_neopixel(vec![[red, green, blue]]);
-                                    ctx.text(json!(package).to_string())
-                                } else {
-                                    ctx.text(json!("Error: Invalid command selected").to_string())
-                                }
-                            }
-                            "pwm" => match v[3] {
-                                "enable" => {
-                                    let _package: AnsPackage;
-                                    if v.len() == 4 {
-                                        ctx.text(
-                                            json!("Error: Invalid command selected").to_string(),
-                                        )
-                                    } else if v.len() == 5 {
-                                        let state: bool = v[4].parse::<bool>().unwrap();
-                                        let package = packages::pwm_enable(state);
-                                        ctx.text(json!(package).to_string())
-                                    } else {
-                                        ctx.text(
-                                            json!("Error: Invalid command selected").to_string(),
-                                        )
-                                    }
-                                }
+                let v: Vec<&str> = text.split("&&").collect();
 
-                                "frequency" => {
-                                    let _package: AnsPackage;
-                                    if v.len() == 4 {
-                                        ctx.text(
-                                            json!("Error: Invalid command selected").to_string(),
-                                        )
-                                    } else if v.len() == 5 {
-                                        let freq: f32 = v[4].parse::<f32>().unwrap();
-                                        let package = packages::set_pwm_freq_hz(freq);
-                                        ctx.text(json!(package).to_string())
-                                    } else {
-                                        ctx.text(
-                                            json!("Error: Invalid command selected").to_string(),
-                                        )
-                                    }
-                                }
-                                _ => {
-                                    let _package: AnsPackage;
-                                    if v.len() == 4 {
-                                        ctx.text(
-                                            json!("Error: Invalid command selected").to_string(),
-                                        )
-                                    } else if v.len() == 5 {
-                                        let value: u16 = v[4].parse::<u16>().unwrap();
-
-                                        let package = packages::pwm_channel_value(
-                                            hardware_manager::PwmChannel::from_str(v[3]).unwrap(),
-                                            value,
-                                        );
-                                        ctx.text(json!(package).to_string())
-                                    } else {
-                                        ctx.text(
-                                            json!("Error: Invalid command selected").to_string(),
-                                        )
-                                    }
-                                }
-                            },
-                            _ => ctx.text(json!("Error: Invalid command selected").to_string()),
-                        },
-                        "get_connected" => {
-                            ctx.text(
-                                json!(self.server.lock().unwrap().get_client_count()).to_string(),
-                            );
-                        }
-                        _ => ctx.text(json!("Error: Invalid command selected").to_string()),
+                for request in v {
+                    let request = request.trim();
+                    if request.starts_with('/') {
+                        ctx.text(request_endpoint(request));
+                    } else {
+                        let error_msg = format!(
+                            "{} {}, missing / ?",
+                            json!("Error: Invalid command:"),
+                            request
+                        );
+                        ctx.text(error_msg)
                     }
-                } else {
-                    ctx.text(json!("Error: Invalid command").to_string())
                 }
             }
             Ok(ws::Message::Binary(bin)) => ctx.binary(bin),

--- a/src/server/protocols/v1/websocket.rs
+++ b/src/server/protocols/v1/websocket.rs
@@ -10,7 +10,10 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use crate::server::protocols::v1::packages;
+use crate::{
+    hardware_manager,
+    server::protocols::v1::{packages, structures::AnsPackage},
+};
 
 pub struct StringMessage(String);
 
@@ -124,6 +127,95 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WebsocketActor {
                                 packages::reading(packages::Sensors::from_str(v[2]).unwrap());
                             ctx.text(json!(package).to_string());
                         }
+                        "output" => match v[2] {
+                            "userled" => {
+                                let package;
+                                if v.len() == 4 {
+                                    package = packages::get_led(
+                                        hardware_manager::UserLed::from_str(v[3]).unwrap(),
+                                    );
+                                    ctx.text(json!(package).to_string())
+                                } else if v.len() == 5 {
+                                    let state: bool = v[4].parse::<bool>().unwrap();
+                                    package = packages::set_led(
+                                        hardware_manager::UserLed::from_str(v[3]).unwrap(),
+                                        state,
+                                    );
+                                    ctx.text(json!(package).to_string())
+                                } else {
+                                    ctx.text(json!("Error: Invalid command selected").to_string())
+                                }
+                            }
+                            "nepixel" => {
+                                if v.len() == 6 {
+                                    let (red, green, blue) = (
+                                        v[3].parse::<u8>().unwrap(),
+                                        v[4].parse::<u8>().unwrap(),
+                                        v[5].parse::<u8>().unwrap(),
+                                    );
+                                    let package = packages::set_neopixel(vec![[red, green, blue]]);
+                                    ctx.text(json!(package).to_string())
+                                } else {
+                                    ctx.text(json!("Error: Invalid command selected").to_string())
+                                }
+                            }
+                            "pwm" => match v[3] {
+                                "enable" => {
+                                    let _package: AnsPackage;
+                                    if v.len() == 4 {
+                                        ctx.text(
+                                            json!("Error: Invalid command selected").to_string(),
+                                        )
+                                    } else if v.len() == 5 {
+                                        let state: bool = v[4].parse::<bool>().unwrap();
+                                        let package = packages::pwm_enable(state);
+                                        ctx.text(json!(package).to_string())
+                                    } else {
+                                        ctx.text(
+                                            json!("Error: Invalid command selected").to_string(),
+                                        )
+                                    }
+                                }
+
+                                "frequency" => {
+                                    let _package: AnsPackage;
+                                    if v.len() == 4 {
+                                        ctx.text(
+                                            json!("Error: Invalid command selected").to_string(),
+                                        )
+                                    } else if v.len() == 5 {
+                                        let freq: f32 = v[4].parse::<f32>().unwrap();
+                                        let package = packages::set_pwm_freq_hz(freq);
+                                        ctx.text(json!(package).to_string())
+                                    } else {
+                                        ctx.text(
+                                            json!("Error: Invalid command selected").to_string(),
+                                        )
+                                    }
+                                }
+                                _ => {
+                                    let _package: AnsPackage;
+                                    if v.len() == 4 {
+                                        ctx.text(
+                                            json!("Error: Invalid command selected").to_string(),
+                                        )
+                                    } else if v.len() == 5 {
+                                        let value: u16 = v[4].parse::<u16>().unwrap();
+
+                                        let package = packages::pwm_channel_value(
+                                            hardware_manager::PwmChannel::from_str(v[3]).unwrap(),
+                                            value,
+                                        );
+                                        ctx.text(json!(package).to_string())
+                                    } else {
+                                        ctx.text(
+                                            json!("Error: Invalid command selected").to_string(),
+                                        )
+                                    }
+                                }
+                            },
+                            _ => ctx.text(json!("Error: Invalid command selected").to_string()),
+                        },
                         "get_connected" => {
                             ctx.text(
                                 json!(self.server.lock().unwrap().get_client_count()).to_string(),


### PR DESCRIPTION
Users now can connect and request output commands, also are able to do multiple requests with &&, doesn't matter if have trailing spaces.

example commands:

```
input/all
input/magnetometer
output/pwm/enable/true
output/pwm/frequency/60
output/pwm/ch1/1000
output/neopixel/100/100/100
output/userled/led1/true
output/userled/led1 -> return state

```
![image](https://github.com/RaulTrombin/navigator-assistant/assets/80598030/3b693cfd-b667-48cc-b823-72e1f411cf49)

it opens a desirable upgrade for navigator-rs, to check if pwm and neopixel are capable to retrieve their actual values.