### PR TITLE
Update: API docs link to metadata

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -14,7 +14,7 @@ pub async fn run() -> std::io::Result<()> {
             .wrap(middleware::Logger::default())
             .wrap_api()
             .with_json_spec_at("/api/spec")
-            .with_swagger_ui_at("/swagger")
+            .with_swagger_ui_at("/docs")
             .service(protocols::v1::rest::index)
             .service(protocols::v1::rest::dist)
             .service(protocols::v1::rest::echo)

--- a/src/server/protocols/v1/structures.rs
+++ b/src/server/protocols/v1/structures.rs
@@ -149,7 +149,7 @@ impl Default for ServerMetadata {
             version: "0.0.1",
             new_page: false,
             webpage: "https://github.com/RaulTrombin/navigator-assistant",
-            api: "https://raultrombin.github.io/navigator-assistant/api",
+            api: "/docs",
         }
     }
 }


### PR DESCRIPTION
Just update metadata do load new swagger and api specs from server.