### PR TITLE
Cargo: fix navigator-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ futures-util = "0.3.28"
 lazy_static = "1.4.0"
 log = "0.4.20"
 mime_guess = "2.0.4"
+navigator-rs = "0.2.1"
 paperclip = { version = "0.8.2" , features = ["actix4", "swagger-ui"] }
 regex = "1.9.5"
 rust-embed = "8.0.0"


### PR DESCRIPTION
I've replaced navigator-rs to paperclip, 
need to create a CI to prevent this, but navigator-rs needs to bump it's version, with new features (copy, clone..).